### PR TITLE
Add middleware + refactor base and User data classes

### DIFF
--- a/app/common.py
+++ b/app/common.py
@@ -4,7 +4,8 @@
 
 from abc import ABC, abstractmethod, abstractclassmethod
 from firebase_admin import auth
-from user_api.errors import UserAuthenticationError
+from .user_api.errors import UserAuthenticationError
+from werkzeug.exceptions import Unauthorized
 import json
 
 
@@ -69,7 +70,7 @@ def decode_token(token):
         dict: A dictionary of the key-value pairs from the decoded JWT
 
     Raises:
-        UserAuthenticationError: if an error occurs authenticating the token
+        Unauthorized: if the token is invalid or expired
         ValueError: if `token` is not a string or is empty
     """
     try:
@@ -77,6 +78,5 @@ def decode_token(token):
     except (
         auth.InvalidIdTokenError,
         auth.ExpiredIdTokenError,
-        auth.CertificateFetchError,
     ) as e:
-        raise UserAuthenticationError(str(e)) from e
+        raise Unauthorized("Invalid token") from e

--- a/app/common.py
+++ b/app/common.py
@@ -3,6 +3,8 @@
 ###
 
 from abc import ABC, abstractmethod, abstractclassmethod
+from firebase_admin import auth
+from user_api.errors import UserAuthenticationError
 import json
 
 
@@ -54,3 +56,27 @@ class BadDataError(Exception):
 
     def __init__(self, message):
         super().__init__(message)
+
+
+def decode_token(token):
+    """
+    Decodes a JWT token using Firebase
+
+    Args:
+        token: A string of the encoded JWT
+
+    Returns:
+        dict: A dictionary of the key-value pairs from the decoded JWT
+
+    Raises:
+        UserAuthenticationError: if an error occurs authenticating the token
+        ValueError: if `token` is not a string or is empty
+    """
+    try:
+        return auth.verify_id_token(token)
+    except (
+        auth.InvalidIdTokenError,
+        auth.ExpiredIdTokenError,
+        auth.CertificateFetchError,
+    ) as e:
+        raise UserAuthenticationError(str(e)) from e

--- a/app/common.py
+++ b/app/common.py
@@ -11,30 +11,18 @@ import json
 
 class FirebaseDataEntity(ABC):
     """
-    Base class for data classes to be used wth Firestore. Supports both fetching an entity
-    from Firestore by ID or pushing/updating a new entity on the remote database
+    Base class for data classes to be used wth Firestore.
     """
 
-    def __init__(self, db_ref):
+    def __init__(self):
         """
-        Initialize new data instance with a specified CollectionReference. Additional parameters should be added to child classes
+        Initialize new data instance. Additional parameters should be added to child classes
         for any needed fields.
         """
-        self.db_reference = db_ref
-
-    @abstractclassmethod
-    def get(db_ref, id):
-        """Class function that fetches a specified entity from a given Firebase reference by ID and creates a new Python instance"""
-        raise NotImplementedError("Base class cannot be used")
 
     @abstractclassmethod
     def from_dict(dict):
         """Class function that creates a new data class from a Python dictionary"""
-        raise NotImplementedError("Base class cannot be used")
-
-    @abstractmethod
-    def push(self):
-        """Pushes data to Firebase"""
         raise NotImplementedError("Base class cannot be used")
 
     def to_json(self):

--- a/app/firebase.py
+++ b/app/firebase.py
@@ -2,6 +2,7 @@ from flask import Flask, jsonify, request
 from firebase_admin import credentials, firestore, initialize_app
 
 EVENTS_COLLECTION = "events"
+USERS_COLLECTION = "users"
 
 # Initializing Firestore database
 # Can import firestore_db to utilize database

--- a/app/user_api/User.py
+++ b/app/user_api/User.py
@@ -29,29 +29,61 @@ class User(common.FirebaseDataEntity):
         self.hasCompletedOnboarding = hasCompletedOnboarding
 
     def get(db_ref, id):
+        """
+        Fetches a specified user from a database.
+
+        Args:
+            db_ref: A `CollectionReference` to the users table from Firestore
+            id: A string of the user email to fetch
+
+        Returns:
+            User: specified by `id`
+
+        Raises:
+            UserNotFoundError: if the target user does not exist
+        """
         target_data = db_ref.document(id).get()
         if not target_data.exists:
             raise UserNotFoundError(id)
         return User.from_dict(db_ref, target_data.to_dict())
 
     def from_dict(db_ref, dict):
+        """
+        Creates a new User object from a Python Dictionary
+
+        Args:
+            db_ref: A `CollectionReference` to the users table from Firestore
+            dict: Dictionary of key-value pairs corresponding to user.
+
+        Returns:
+            User: from specified data
+
+        Raises:
+            BadDataError: If required data is missing from the dictionary
+        """
         try:
             return User(
                 db_ref,
                 dict["email"],
-                dict["referral_code"],
-                dict["reward_point_balance"],
-                dict["notification_setting"],
-                dict["color_theme"],
-                dict["time_in_line"],
-                dict["num_lines_participated"],
-                dict["poi_frequency"],
-                dict["hasCompletedOnboarding"],
+                dict.get("referral_code", ""),
+                dict.get("reward_point_balance", 0),
+                dict.get("notification_setting", False),
+                dict.get("color_theme", "SYSTEM"),
+                dict.get("time_in_line", 0),
+                dict.get("num_lines_participated", 0),
+                dict.get("poi_frequency", {}),
+                dict.get("hasCompletedOnboarding", False),
             )
         except KeyError as e:
             raise common.BadDataError("Missing data from user data: " + str(e))
 
     def to_dict(self):
+        """
+        Returns a dictionary containing all properties from the User
+
+        Returns:
+            dict: containing key-value pairs with all User data
+        """
         new_dict = {
             "email": self.email,
             "referral_code": self.referral_code,
@@ -66,6 +98,7 @@ class User(common.FirebaseDataEntity):
         return new_dict
 
     def push(self, merge=True):
+        """Pushes data to Firebase"""
         target_ref = self.db_reference.document(self.email)
         target_ref.set(self.to_dict(), merge=merge)
 

--- a/app/user_api/User.py
+++ b/app/user_api/User.py
@@ -40,13 +40,13 @@ class User(common.FirebaseDataEntity):
         try:
             return User(
                 dict["email"],
-                dict.get("referral_code", ""),
-                dict.get("reward_point_balance", 0),
-                dict.get("notification_setting", False),
-                dict.get("time_in_line", 0),
-                dict.get("num_lines_participated", 0),
-                dict.get("poi_frequency", {}),
-                dict.get("hasCompletedOnboarding", False),
+                dict["referral_code"],
+                dict["reward_point_balance"],
+                dict["notification_setting"],
+                dict["time_in_line"],
+                dict["num_lines_participated"],
+                dict["poi_frequency"],
+                dict["hasCompletedOnboarding"],
             )
         except KeyError as e:
             raise common.BadDataError("Missing data from user data: " + str(e))

--- a/app/user_api/User.py
+++ b/app/user_api/User.py
@@ -6,53 +6,29 @@ import json
 class User(common.FirebaseDataEntity):
     def __init__(
         self,
-        db_ref,
         email,
         referral_code="",
         reward_point_balance=0,
         notification_setting=False,
-        color_theme="SYSTEM",
         time_in_line=0,
         num_lines_participated=0,
         poi_frequency={},
         hasCompletedOnboarding=False,
     ):
-        super().__init__(db_ref)
         self.email = email
         self.referral_code = referral_code
         self.reward_point_balance = reward_point_balance
         self.notification_setting = notification_setting
-        self.color_theme = color_theme
         self.time_in_line = time_in_line
         self.num_lines_participated = num_lines_participated
         self.poi_frequency = poi_frequency
         self.hasCompletedOnboarding = hasCompletedOnboarding
 
-    def get(db_ref, id):
-        """
-        Fetches a specified user from a database.
-
-        Args:
-            db_ref: A `CollectionReference` to the users table from Firestore
-            id: A string of the user email to fetch
-
-        Returns:
-            User: specified by `id`
-
-        Raises:
-            UserNotFoundError: if the target user does not exist
-        """
-        target_data = db_ref.document(id).get()
-        if not target_data.exists:
-            raise UserNotFoundError(id)
-        return User.from_dict(db_ref, target_data.to_dict())
-
-    def from_dict(db_ref, dict):
+    def from_dict(dict):
         """
         Creates a new User object from a Python Dictionary
 
         Args:
-            db_ref: A `CollectionReference` to the users table from Firestore
             dict: Dictionary of key-value pairs corresponding to user.
 
         Returns:
@@ -63,12 +39,10 @@ class User(common.FirebaseDataEntity):
         """
         try:
             return User(
-                db_ref,
                 dict["email"],
                 dict.get("referral_code", ""),
                 dict.get("reward_point_balance", 0),
                 dict.get("notification_setting", False),
-                dict.get("color_theme", "SYSTEM"),
                 dict.get("time_in_line", 0),
                 dict.get("num_lines_participated", 0),
                 dict.get("poi_frequency", {}),
@@ -89,18 +63,12 @@ class User(common.FirebaseDataEntity):
             "referral_code": self.referral_code,
             "reward_point_balance": self.reward_point_balance,
             "notification_setting": self.notification_setting,
-            "color_theme": self.color_theme,
             "time_in_line": self.time_in_line,
             "num_lines_participated": self.num_lines_participated,
             "poi_frequency": self.poi_frequency,
             "hasCompletedOnboarding": self.hasCompletedOnboarding,
         }
         return new_dict
-
-    def push(self, merge=True):
-        """Pushes data to Firebase"""
-        target_ref = self.db_reference.document(self.email)
-        target_ref.set(self.to_dict(), merge=merge)
 
     def __eq__(self, other):
         return self.email == other.email

--- a/app/user_api/spec.yaml
+++ b/app/user_api/spec.yaml
@@ -5,6 +5,12 @@ info:
   version: "1.0.0"
 
 components:
+  securitySchemes:
+    jwt:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      x-bearerInfoFunc: app.common.decode_token
   schemas:
     User:
       type: "object"
@@ -70,3 +76,19 @@ paths:
       responses:
         "200":
           description: User deleted
+  /user/test_authenticate:
+    get:
+      x-openapi-router-controller: app.user_api.user_api
+      operationId: test_authenticate
+      tags:
+        - User
+      summary: "Authenticate using a JWT token"
+      responses:
+        "200":
+          description: Successful authentication, return user email"
+          content:
+            'text/plain':
+              schema:
+                type: string
+      security:
+      - jwt: []

--- a/app/user_api/spec.yaml
+++ b/app/user_api/spec.yaml
@@ -5,12 +5,6 @@ info:
   version: "1.0.0"
 
 components:
-  securitySchemes:
-    jwt:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
-      x-bearerInfoFunc: app.common.decode_token
   schemas:
     User:
       type: "object"

--- a/app/user_api/user_api.py
+++ b/app/user_api/user_api.py
@@ -29,10 +29,10 @@ def delete_user_profile(email):
     return {"message": "Success"}, 200
 
 
-def test_authenticate(user, token_info):
+def test_authenticate(token_info):
     try:
-        new_user = auth.get_user(token_info["uid"])
-        return f"Success, you are {user}", 200
+        user = auth.get_user(token_info["uid"])
+        return f"Success, you are {user.email}", 200
     except ValueError as e:
         return {"error": "Invalid user ID", "details": str(e)}, 400
     except auth.UserNotFoundError as e:

--- a/app/user_api/user_api.py
+++ b/app/user_api/user_api.py
@@ -1,16 +1,14 @@
-from .user_service import User_Service
+from . import user_service
 from .errors import UserNotFoundError, UserAuthenticationError
 from .User import User
 from flask import jsonify
 from firebase_admin import auth
 import jwt
 
-user_service = User_Service()
-
 
 def get_user_profile(email):
     try:
-        user = user_service.findUser(email)
+        user = user_service.find_user(email)
     except UserNotFoundError:
         return {"error": "User not found"}, 404
     except Exception as e:
@@ -20,8 +18,8 @@ def get_user_profile(email):
 
 def delete_user_profile(email):
     try:
-        target_user = user_service.findUser(email)
-        user = user_service.deleteUser(target_user)
+        target_user = user_service.find_user(email)
+        user = user_service.delete_user(target_user)
     except UserNotFoundError:
         return {"error": "User not found"}, 404
     except Exception as e:

--- a/app/user_api/user_api.py
+++ b/app/user_api/user_api.py
@@ -1,7 +1,9 @@
 from .user_service import User_Service
-from .errors import UserNotFoundError
+from .errors import UserNotFoundError, UserAuthenticationError
 from .User import User
 from flask import jsonify
+from firebase_admin import auth
+import jwt
 
 user_service = User_Service()
 
@@ -25,3 +27,15 @@ def delete_user_profile(email):
     except Exception as e:
         return {"error": str(e)}, 500
     return {"message": "Success"}, 200
+
+
+def test_authenticate(user, token_info):
+    try:
+        new_user = auth.get_user(token_info["uid"])
+        return f"Success, you are {user}", 200
+    except ValueError as e:
+        return {"error": "Invalid user ID", "details": str(e)}, 400
+    except auth.UserNotFoundError as e:
+        return {"error": "User not found", "details": str(e)}, 404
+    except Exception as e:
+        return {"error": str(e)}, 500

--- a/app/user_api/user_service.py
+++ b/app/user_api/user_service.py
@@ -11,7 +11,18 @@ class User_Service:
         self.users_ref = firestore.client().collection("users")
 
     def findUser(self, email):
-        """Given email, find and return corresponding User. Raises UserNotFoundError if user not found"""
+        """Given email, find and return corresponding User. Raises UserNotFoundError if user not found
+
+         Args:
+             email: A string of the target user email
+
+        Returns:
+             User: An associated User object with the specified email
+
+         Raises:
+             UserNotFoundError: if user with specified email does not exist
+             BadDataError: if user data retrieved is missing essential data
+        """
         return User.get(self.users_ref, email)
 
     def updateUser(self, user):
@@ -35,7 +46,15 @@ class User_Service:
         return user.time_in_line
 
     def deleteUser(self, user):
-        """Deletes a specified user"""
+        """
+        Deletes a specified user
+
+        Args:
+            user: User object for target user to delete
+
+        Raises:
+            UserNotFoundError: If target user does not exist
+        """
         target_user_snapshot = self.users_ref.document(user.email)
         if not target_user_snapshot.get().exists:
             raise UserNotFoundError(user.email)

--- a/app/user_api/user_service.py
+++ b/app/user_api/user_service.py
@@ -6,57 +6,61 @@ from app.firebase import firestore_db, USERS_COLLECTION
 users_collection = firestore_db.collection(USERS_COLLECTION)
 
 
-class User_Service:
-    """This is the service class for the User API"""
+def find_user(email: str) -> User:
+    """Given email, find and return corresponding User. Raises UserNotFoundError if user not found
 
-    def findUser(self, email: str) -> User:
-        """Given email, find and return corresponding User. Raises UserNotFoundError if user not found
+    :param email: A string of the target user email
+    :returns: An associated User object with the specified email
+    :raises UserNotFoundError: if user with specified email does not exist
+    :raises BadDataError: if user data retrieved is missing essential data
+    """
+    user_ref = users_collection.document(email).get()
+    if not user_ref.exists:
+        raise UserNotFoundError(email)
+    return User.from_dict(user_ref.to_dict())
 
-        :param email: A string of the target user email
-        :returns: An associated User object with the specified email
-        :raises UserNotFoundError: if user with specified email does not exist
-        :raises BadDataError: if user data retrieved is missing essential data
-        """
-        user_ref = users_collection.document(email).get()
-        if not user_ref.exists:
-            raise UserNotFoundError(email)
-        return User.from_dict(user_ref.to_dict())
 
-    def updateUser(self, user: User):
-        """Push updated User object to Firestore"""
-        users_collection.document(user.email).set(user.to_dict(), merge=True)
+def update_user(user: User):
+    """Push updated User object to Firestore"""
+    users_collection.document(user.email).set(user.to_dict(), merge=True)
 
-    def getPoints(self, user: User):
-        """Returns user's reward points balance"""
-        return user.reward_point_balance
 
-    def getPOIFrequency(self, user: User):
-        """Return POI object"""
-        pass  # TODO
+def get_points(user: User):
+    """Returns user's reward points balance"""
+    return user.reward_point_balance
 
-    def getNumLinesParticipated(self, user: User):
-        """Returns number of lines participated in by a User"""
-        return user.num_lines_participated
 
-    def getTotalLineTime(self, user: User):
-        """Return total time in line spent by User as an integer"""
-        return user.time_in_line
+def get_POI_frequency(user: User):
+    """Return POI object"""
+    pass  # TODO
 
-    def deleteUser(self, user: User):
-        """
-        Deletes a specified user
 
-        :param user: User object for target user to delete
-        :raises UserNotFoundError: If target user does not exist
-        """
-        target_user_snapshot = users_collection.document(user.email)
-        if not target_user_snapshot.get().exists:
-            raise UserNotFoundError(user.email)
-        target_user_snapshot.delete()
-        # TODO if there are any other references to the user that need to be deleted from other places,
-        # add them here
+def get_num_lines_participated(user: User):
+    """Returns number of lines participated in by a User"""
+    return user.num_lines_participated
 
-    def updateNotification(self, user, setting):
-        """Updates notification preference for specfied user"""
-        user.notification_setting = setting
-        self.updateUser(user)
+
+def get_total_line_time(user: User):
+    """Return total time in line spent by User as an integer"""
+    return user.time_in_line
+
+
+def delete_user(user: User):
+    """
+    Deletes a specified user
+
+    :param user: User object for target user to delete
+    :raises UserNotFoundError: If target user does not exist
+    """
+    target_user_snapshot = users_collection.document(user.email)
+    if not target_user_snapshot.get().exists:
+        raise UserNotFoundError(user.email)
+    target_user_snapshot.delete()
+    # TODO if there are any other references to the user that need to be deleted from other places,
+    # add them here
+
+
+def update_notification(user, setting):
+    """Updates notification preference for specfied user"""
+    user.notification_setting = setting
+    update_user(user)

--- a/app/user_api/user_service.py
+++ b/app/user_api/user_service.py
@@ -1,73 +1,62 @@
 # This file contains service functions for the user API
 from app.user_api.User import User
 from app.user_api.errors import UserNotFoundError, UserAuthenticationError
-from firebase_admin import firestore
+from app.firebase import firestore_db, USERS_COLLECTION
+
+users_collection = firestore_db.collection(USERS_COLLECTION)
 
 
 class User_Service:
     """This is the service class for the User API"""
 
-    def __init__(self):
-        self.users_ref = firestore.client().collection("users")
-
-    def findUser(self, email):
+    def findUser(self, email: str) -> User:
         """Given email, find and return corresponding User. Raises UserNotFoundError if user not found
 
-         Args:
-             email: A string of the target user email
-
-        Returns:
-             User: An associated User object with the specified email
-
-         Raises:
-             UserNotFoundError: if user with specified email does not exist
-             BadDataError: if user data retrieved is missing essential data
+        :param email: A string of the target user email
+        :returns: An associated User object with the specified email
+        :raises UserNotFoundError: if user with specified email does not exist
+        :raises BadDataError: if user data retrieved is missing essential data
         """
-        return User.get(self.users_ref, email)
+        user_ref = users_collection.document(email).get()
+        if not user_ref.exists:
+            raise UserNotFoundError(email)
+        return User.from_dict(user_ref.to_dict())
 
-    def updateUser(self, user):
+    def updateUser(self, user: User):
         """Push updated User object to Firestore"""
-        user.push()
+        users_collection.document(user.email).set(user.to_dict(), merge=True)
 
-    def getPoints(self, user):
+    def getPoints(self, user: User):
         """Returns user's reward points balance"""
         return user.reward_point_balance
 
-    def getPOIFrequency(self, user):
+    def getPOIFrequency(self, user: User):
         """Return POI object"""
         pass  # TODO
 
-    def getNumLinesParticipated(self, user):
+    def getNumLinesParticipated(self, user: User):
         """Returns number of lines participated in by a User"""
         return user.num_lines_participated
 
-    def getTotalLineTime(self, user):
+    def getTotalLineTime(self, user: User):
         """Return total time in line spent by User as an integer"""
         return user.time_in_line
 
-    def deleteUser(self, user):
+    def deleteUser(self, user: User):
         """
         Deletes a specified user
 
-        Args:
-            user: User object for target user to delete
-
-        Raises:
-            UserNotFoundError: If target user does not exist
+        :param user: User object for target user to delete
+        :raises UserNotFoundError: If target user does not exist
         """
-        target_user_snapshot = self.users_ref.document(user.email)
+        target_user_snapshot = users_collection.document(user.email)
         if not target_user_snapshot.get().exists:
             raise UserNotFoundError(user.email)
         target_user_snapshot.delete()
         # TODO if there are any other references to the user that need to be deleted from other places,
         # add them here
 
-    def changeTheme(self, user, theme):
-        """Updates theme for a specified User"""
-        user.color_theme = theme
-        user.push()
-
-    def updateNotification(user, setting):
+    def updateNotification(self, user, setting):
         """Updates notification preference for specfied user"""
         user.notification_setting = setting
-        user.push()
+        self.updateUser(user)

--- a/base_swagger.yaml
+++ b/base_swagger.yaml
@@ -10,6 +10,14 @@ info:
   description: "QueueTime API for finding wait times of various points of interests at McMaster University"
   version: "1.0.0"
 
+components:
+  securitySchemes:
+    jwt:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      x-bearerInfoFunc: app.common.decode_token
+
 # # By providing "/api" as the value of url, you’ll be able to access all of your API paths relative to http://localhost:xxxx/api.
 servers:
   - url: "/api"

--- a/test/events/test_service.py
+++ b/test/events/test_service.py
@@ -15,7 +15,7 @@ class TestEventService(unittest.TestCase):
         self.email = "test@sample.ca"
         self.poi_id = "SAMPLE_POI"
         self.points_awarded = 25
-        self.user = User(None, self.email, "XJFEKDG", 0)
+        self.user = User(self.email, "XJFEKDG", 0)
         self.poi = POI(
             self.poi_id, "Testing poi", "Testing", None, None, None, None, None
         )
@@ -107,7 +107,7 @@ class TestEventService(unittest.TestCase):
 
     def test_generate_referral_event(self, firebase_mock):
         referral_email = "refferer@sample.com"
-        same_referral_user = User(None, referral_email, "ASDKGUE")
+        same_referral_user = User(referral_email, "ASDKGUE")
 
         event_service.generate_referral_event(
             self.user, same_referral_user, self.points_awarded

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -1,5 +1,6 @@
 import unittest
-from firebase_admin import credentials, initialize_app, firestore
+from firebase_admin import firestore
+from app import firebase
 from app.user_api.User import User
 from app.user_api.errors import UserNotFoundError
 from app.user_api import user_service
@@ -10,8 +11,6 @@ import json
 class TestUser(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        cred = credentials.Certificate("./serviceAccountKey.json")
-        self.default_app = initialize_app(cred)
         self.firestore_db = firestore.client()
         self.users_ref = self.firestore_db.collection("users")
 

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -43,7 +43,6 @@ class TestUser(unittest.TestCase):
 class TestUserService(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.user_service = user_service.User_Service()
         self.sample_user_dict = {
             "email": "test@test.com",
             "referral_code": "",
@@ -69,22 +68,22 @@ class TestUserService(unittest.TestCase):
         user_collection_mock.document().get().to_dict = MagicMock(
             return_value=self.sample_user_dict
         )
-        self.assertEqual(self.sample_user, self.user_service.findUser("test@test.com"))
+        self.assertEqual(self.sample_user, user_service.find_user("test@test.com"))
         user_collection_mock.document().get().exists = False
         self.assertRaises(
-            UserNotFoundError, self.user_service.findUser, "test@nonexistent.com"
+            UserNotFoundError, user_service.find_user, "test@nonexistent.com"
         )
 
     def test_delete_user(self, user_collection_mock):
-        self.user_service.deleteUser(self.sample_user)
+        user_service.delete_user(self.sample_user)
         user_collection_mock.document().delete.assert_called_once()
         user_collection_mock.document().get().exists = False
         self.assertRaises(
             UserNotFoundError,
-            self.user_service.deleteUser,
+            user_service.delete_user,
             User("test@nonexistent.com"),
         )
 
     def test_update_user(self, user_collection_mock):
-        self.user_service.updateUser(self.sample_user)
+        user_service.update_user(self.sample_user)
         user_collection_mock.document().set.assert_called_once()

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch, Mock, MagicMock
 from firebase_admin import firestore
 from app import firebase
 from app.user_api.User import User
@@ -11,48 +12,79 @@ import json
 class TestUser(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.firestore_db = firestore.client()
-        self.users_ref = self.firestore_db.collection("users")
-
-    def test_user_push_and_fetch(self):
-        user = User(self.users_ref, "test@test.com", "", 0, False, "", 0, 0, {}, False)
-        user.push()
-        fetched_user = User.get(self.users_ref, "test@test.com")
-        self.assertEqual(user.to_json(), fetched_user.to_json())
-
-    def test_error_handling(self):
-        self.assertRaises(
-            UserNotFoundError, User.get, self.users_ref, "test@nonexistent.com"
+        self.sample_user_dict = {
+            "email": "test@test.com",
+            "referral_code": "",
+            "reward_point_balance": 0,
+            "notification_setting": False,
+            "time_in_line": 0,
+            "num_lines_participated": 0,
+            "poi_frequency": {},
+            "hasCompletedOnboarding": False,
+        }
+        self.sample_user = User(
+            email="test@test.com",
+            referral_code="",
+            reward_point_balance=0,
+            notification_setting=False,
+            time_in_line=0,
+            num_lines_participated=0,
+            poi_frequency={},
+            hasCompletedOnboarding=False,
         )
 
-    def tearDown(self):
-        self.users_ref.document("test@test.com").delete()
+    def test_to_from_dict(self):
+        self.assertEqual(
+            self.sample_user.to_json(), User.from_dict(self.sample_user_dict).to_json()
+        )
 
 
+@patch("app.user_api.user_service.users_collection")
 class TestUserService(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.firestore_db = firestore.client()
-        self.users_ref = self.firestore_db.collection("users")
         self.user_service = user_service.User_Service()
-        self.test_user = User(
-            self.users_ref, "test@test.com", "", 0, False, "", 0, 0, {}, False
+        self.sample_user_dict = {
+            "email": "test@test.com",
+            "referral_code": "",
+            "reward_point_balance": 0,
+            "notification_setting": False,
+            "time_in_line": 0,
+            "num_lines_participated": 0,
+            "poi_frequency": {},
+            "hasCompletedOnboarding": False,
+        }
+        self.sample_user = User(
+            email="test@test.com",
+            referral_code="",
+            reward_point_balance=0,
+            notification_setting=False,
+            time_in_line=0,
+            num_lines_participated=0,
+            poi_frequency={},
+            hasCompletedOnboarding=False,
         )
-        self.test_user.push()
 
-    def test_find_user(self):
-        self.assertEqual(self.test_user, self.user_service.findUser("test@test.com"))
+    def test_find_user(self, user_collection_mock):
+        user_collection_mock.document().get().to_dict = MagicMock(
+            return_value=self.sample_user_dict
+        )
+        self.assertEqual(self.sample_user, self.user_service.findUser("test@test.com"))
+        user_collection_mock.document().get().exists = False
         self.assertRaises(
             UserNotFoundError, self.user_service.findUser, "test@nonexistent.com"
         )
 
-    def test_delete_user(self):
+    def test_delete_user(self, user_collection_mock):
+        self.user_service.deleteUser(self.sample_user)
+        user_collection_mock.document().delete.assert_called_once()
+        user_collection_mock.document().get().exists = False
         self.assertRaises(
             UserNotFoundError,
             self.user_service.deleteUser,
-            User(self.users_ref, "test@nonexistent.com"),
+            User("test@nonexistent.com"),
         )
-        self.user_service.deleteUser(self.test_user)
-        self.assertRaises(UserNotFoundError, User.get, self.users_ref, "test@test.com")
-        # cleanup
-        self.test_user.push()
+
+    def test_update_user(self, user_collection_mock):
+        self.user_service.updateUser(self.sample_user)
+        user_collection_mock.document().set.assert_called_once()


### PR DESCRIPTION
## Overview

Included all middleware changes from PR #22 with the following changes:

- Changed Google Pydoc documentation style to reST
- Refactored user service class, base data class (common.FirebaseDataEntity), and User class to remove all database logic (@dizona you will need to do the same for any POI classes)
- Updated user tests to mock all Firebase calls

This change is a

- [x] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that will change exisiting functionality)
- [x] Documentation update


Notes about middleware: at the moment, any endpoint secured in the OpenAPI specification will pass token info to the `token_info` argument of the endpoint function, and the endpoint function can optionally have a `user` parameter which will have the uid passed to it. In the future, I will add a decorator function so that instead of passing the uid to the `user` parameter, it will pass a `User` object.
