### PR TITLE
[Fix] Fix tests to run without breaking when firebase spec key isn't present

### DIFF
--- a/app/firebase.py
+++ b/app/firebase.py
@@ -1,12 +1,11 @@
-from flask import Flask, jsonify, request
-from firebase_admin import credentials, firestore, initialize_app
+from firebase_admin import firestore
 
 EVENTS_COLLECTION = "events"
 USERS_COLLECTION = "users"
 REFERRAL_CODES_COLLECTION = "referral_codes"
 
-# Initializing Firestore database
-# Can import firestore_db to utilize database
-cred = credentials.Certificate("serviceAccountKey.json")
-default_app = initialize_app(cred)
+# # Initializing Firestore database
+# # Can import firestore_db to utilize database
+# cred = credentials.Certificate("serviceAccountKey.json")
+# default_app = initialize_app(cred)
 firestore_db = firestore.client()

--- a/app/firebase.py
+++ b/app/firebase.py
@@ -4,8 +4,4 @@ EVENTS_COLLECTION = "events"
 USERS_COLLECTION = "users"
 REFERRAL_CODES_COLLECTION = "referral_codes"
 
-# # Initializing Firestore database
-# # Can import firestore_db to utilize database
-# cred = credentials.Certificate("serviceAccountKey.json")
-# default_app = initialize_app(cred)
 firestore_db = firestore.client()

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,15 @@
 import connexion
 from utils import combine_specifications
+from firebase_admin import credentials, initialize_app
 
+
+# Initializing Firestore database
+# Can import firestore_db to utilize database
+def initialize_firebase():
+    initialize_app(credentials.Certificate("serviceAccountKey.json"))
+
+
+initialize_firebase()
 app = connexion.App(__name__)
 # Tell app to read the combined openapi specification
 app.add_api(

--- a/test/events/test_service.py
+++ b/test/events/test_service.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch, Mock, MagicMock, ANY, call
 
+from test.mock_firebase_admin import firebase_admin
 from app.events import service as event_service
 from app.user.api import User
 from app.poi_api.poi import POI

--- a/test/mock_firebase_admin.py
+++ b/test/mock_firebase_admin.py
@@ -1,0 +1,10 @@
+from unittest.mock import Mock
+import sys
+import types
+from typing import Any
+
+module_name = "firebase_admin"
+firebase_admin: Any = types.ModuleType(module_name)
+sys.modules[module_name] = firebase_admin
+firebase_admin.firestore = Mock(name=module_name + ".firestore")
+firebase_admin.auth = Mock(name=module_name + ".auth")

--- a/test/mock_firebase_admin.py
+++ b/test/mock_firebase_admin.py
@@ -3,6 +3,14 @@ import sys
 import types
 from typing import Any
 
+# Mocks the firebase_admin module
+#
+# Usage
+# Add this import line *above* any modules that would import firebase_admin
+# from test.mock_firebase_admin import firebase_admin # Mock firebase_admin module
+#
+# Add to this file as needed for additional methods and attributes on the module
+
 module_name = "firebase_admin"
 firebase_admin: Any = types.ModuleType(module_name)
 sys.modules[module_name] = firebase_admin

--- a/test/user/test_user.py
+++ b/test/user/test_user.py
@@ -1,5 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
+
+from test.mock_firebase_admin import firebase_admin
 from app.user.user import User
 from app.user.errors import UserNotFoundError
 from app.user.service import find_user, delete_user, update_user, create_user


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Implements mock `firebase_admin` module to use with tests that need to import from firebase. Add it to the tests so that they pass on CI.

Tests should now be fixed once @dizona updates his tests to mock the firebase module.

This change is a

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change exisiting functionality)
- [ ] Documentation update

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->

## Motivation/Links
Tests need to pass on CI as well as local.
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
