### PR TITLE
[FIX] Spec to use enums for rewards endpoint & post for user signup

### DIFF
--- a/app/rewards/spec.yaml
+++ b/app/rewards/spec.yaml
@@ -15,6 +15,8 @@ components:
       properties:
         source:
           type: string
+          enum:
+            [referral_bonus, referred_bonus, waittime_confirm, waittime_submit]
           description: Source of the reward points change
           example: referral_bonus
         points:

--- a/app/user/spec.yaml
+++ b/app/user/spec.yaml
@@ -44,7 +44,7 @@ paths:
         "404":
           description: User not found
   /user/signup:
-    put:
+    post:
       x-openapi-router-controller: app.user.api
       operationId: new_user_signup
       tags:


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Fixes the spec to use enum for the source of reward points and POST for user signup endpoint.

This change is a

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change exisiting functionality)
- [ ] Documentation update

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->

## Motivation/Links
Minor fix to follow conventions and easier debugging in frontend.
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
