### PR TITLE
[FEAT] [Computation] POI Pool wait time

### DIFF
--- a/app/base_api_error.py
+++ b/app/base_api_error.py
@@ -2,7 +2,7 @@ from flask import jsonify
 
 
 class BaseApiError(Exception):
-    def __init__(self, message, error_code):
+    def __init__(self, message: str, error_code: int):
         super().__init__(message)
         self.message = message
         self.error_code = error_code

--- a/app/common.py
+++ b/app/common.py
@@ -12,8 +12,8 @@ from app.base_api_error import BaseApiError
 class BadDataError(BaseApiError):
     """Used when receiving unexpected data from Firebase or clients"""
 
-    def __init__(self, message):
-        super().__init__(message, 400)
+    def __init__(self, message: str, error_code: int = 400):
+        super().__init__(message, error_code)
 
 
 class SimpleMap:

--- a/app/firebase.py
+++ b/app/firebase.py
@@ -6,6 +6,7 @@ REFERRAL_CODES_COLLECTION = "referral_codes"
 LOCATION_COLLECTION = "location"
 POI_COLLECTION = "POI"
 POI_PROPOSAL_COLLECTION = "POI_proposal"
+POI_POOL_COLLECTION = "poi_pool"
 
 
 def firestore_db():

--- a/app/user/service.py
+++ b/app/user/service.py
@@ -37,7 +37,7 @@ def find_user_by_referral_code(referral_code: str) -> User:
     """
     user_ref = users_collection().where("referral_code", "==", referral_code).get()
     if not user_ref:
-        raise UserNotFoundError(referral_code)
+        raise UserNotFoundError(referral_code=referral_code)
     return User.from_dict(user_ref[0].id, user_ref[0].to_dict())
 
 

--- a/app/user/user.py
+++ b/app/user/user.py
@@ -62,7 +62,10 @@ class User:
         Returns:
             dict: containing key-value pairs with all User data
         """
-        return self.__dict__
+        dict = self.__dict__.copy()
+        # Delete primary key before returning dict
+        del dict["email"]
+        return dict
 
     def to_json(self) -> str:
         """Return all properties in a JSON string"""

--- a/app/wait_time/api.py
+++ b/app/wait_time/api.py
@@ -21,6 +21,7 @@ def update_user_location(
     Latitide is expected to be a float between -90 and 90. Longitude is expected to be
     a float between -180 and 180
     """
+    # TODO: check user proximity to nearby POIs and place them in the appropriate POI pool
     user_location = UserLocation.from_dict(uid_to_aid(token_info["uid"]), location_data)
     update_location(user_location)
     return None, 204

--- a/app/wait_time/errors.py
+++ b/app/wait_time/errors.py
@@ -3,9 +3,9 @@ from app.base_api_error import BaseApiError
 
 class POIPoolNotFoundError(BaseApiError):
     def __init__(self, poi_id: str):
-        super.__init__(f"Pool not found for POI ID: {poi_id}", 500)
+        super().__init__(f"Pool not found for POI ID: {poi_id}", 500)
 
 
 class UserNotInPoolError(BaseApiError):
     def __init__(self, user: str, poi_id: str):
-        super.__init__(f"User {user.email} not found in pool for POI: {poi_id}", 500)
+        super().__init__(f"User {user} not found in pool for POI: {poi_id}", 500)

--- a/app/wait_time/errors.py
+++ b/app/wait_time/errors.py
@@ -1,0 +1,11 @@
+from app.base_api_error import BaseApiError
+
+
+class POIPoolNotFoundError(BaseApiError):
+    def __init__(self, poi_id: str):
+        super.__init__(f"Pool not found for POI ID: {poi_id}", 500)
+
+
+class UserNotInPoolError(BaseApiError):
+    def __init__(self, user: str, poi_id: str):
+        super.__init__(f"User {user.email} not found in pool for POI: {poi_id}", 500)

--- a/app/wait_time/errors.py
+++ b/app/wait_time/errors.py
@@ -9,3 +9,8 @@ class POIPoolNotFoundError(BaseApiError):
 class UserNotInPoolError(BaseApiError):
     def __init__(self, user: str, poi_id: str):
         super().__init__(f"User {user} not found in pool for POI: {poi_id}", 500)
+
+
+class UserAlreadyInPoolError(BaseApiError):
+    def __init__(self, user: str, pool_id: str):
+        super().__init__(f"User {user} is already in POI Pool: {pool_id}", 500)

--- a/app/wait_time/location.py
+++ b/app/wait_time/location.py
@@ -49,7 +49,10 @@ class UserLocation:
 
         :returns: dictionary containing key-value pairs with all UserLocation data
         """
-        return self.__dict__
+        dict = self.__dict__
+        # Delete primary key before returning dict
+        del dict["aid"]
+        return dict
 
     def to_json(self) -> str:
         """Return all properties in a JSON string"""

--- a/app/wait_time/location.py
+++ b/app/wait_time/location.py
@@ -49,7 +49,7 @@ class UserLocation:
 
         :returns: dictionary containing key-value pairs with all UserLocation data
         """
-        dict = self.__dict__
+        dict = self.__dict__.copy()
         # Delete primary key before returning dict
         del dict["aid"]
         return dict

--- a/app/wait_time/location.py
+++ b/app/wait_time/location.py
@@ -45,9 +45,9 @@ class UserLocation:
 
     def to_dict(self) -> Dict[str, Any]:
         """
-        Returns a dictionary containing all properties from the User
+        Returns a dictionary containing all properties from the UserLocation
 
-        :returns: dictionary containing key-value pairs with all User data
+        :returns: dictionary containing key-value pairs with all UserLocation data
         """
         return self.__dict__
 

--- a/app/wait_time/service.py
+++ b/app/wait_time/service.py
@@ -99,7 +99,8 @@ def add_user_to_poi_pool(user: User, poi: POI):
     :raises POIPoolNotFoundError: if there is no POIPool for the specified POI
     """
     poi_pool: POIPool = get_pool_for_poi(poi)
-    if get_user_current_poi_pool(user):
+    # Check if user is in a different pool
+    if get_user_current_poi_pool(user) and not poi_pool.is_user_in_pool(user.email):
         raise UserAlreadyInPoolError(user.email, poi.id)
     poi_pool.update_user_in_pool(user.email)
     save_poi_pool(poi_pool)

--- a/app/wait_time/service.py
+++ b/app/wait_time/service.py
@@ -63,7 +63,7 @@ def compute_wait_time_for_poi(poi: POI) -> int:
     Compute the wait time for a specified POI in minutes
 
     :param poi: Specified poi to calculate wait time
-    :returns:
+    :returns: int corresponding to wait time in minutes
     """
     # TODO: Histogram and manual time submission calculations to be added to this
     return ceil(compute_wait_time_from_poi_pool(poi))

--- a/app/wait_time/service.py
+++ b/app/wait_time/service.py
@@ -1,15 +1,23 @@
 # Service class for the Wait Time API
-
-from app.firebase import firestore_db, LOCATION_COLLECTION
+from typing import Optional
+from app.firebase import firestore_db, LOCATION_COLLECTION, POI_POOL_COLLECTION
 from app.user.user import User
 from app.wait_time.location import UserLocation
+from app.locations.poi import POI
 from app.events.service import generate_waittime_submit_event
 from app.locations.service import get_details_for_POI
 from app.rewards.reward_values import POINTS_FOR_TIME_SUBMISSION
+from .sourcing_data import POIPool
+from .errors import POIPoolNotFoundError
+from math import ceil
 
 
 def location_collection():
     return firestore_db().collection(LOCATION_COLLECTION)
+
+
+def poi_pool_collection():
+    return firestore_db().collection(POI_POOL_COLLECTION)
 
 
 def uid_to_aid(uid: str) -> str:
@@ -48,3 +56,97 @@ def add_wait_time_suggestion(user: User, poi_id: str, time_estimate: int):
     generate_waittime_submit_event(
         user, get_details_for_POI(poi_id), time_estimate, POINTS_FOR_TIME_SUBMISSION
     )
+
+
+def compute_wait_time_for_poi(poi: POI) -> int:
+    """
+    Compute the wait time for a specified POI in minutes
+
+    :param poi: Specified poi to calculate wait time
+    :returns:
+    """
+    # TODO: Histogram and manual time submission calculations to be added to this
+    return ceil(compute_wait_time_from_poi_pool(poi))
+
+
+### POI Pool functions
+def get_pool_for_poi(poi: POI) -> POIPool:
+    """
+    Fetches a POIPool from a specified POI
+
+    :param poi: POI corresponding to desired POIPool
+    :returns: POIPool corresponding to specified POI
+    :raises POIPoolNotFoundError: if there is no POIPool for the specified POI
+    """
+    return _get_pool_for_poi_id(poi.id)
+
+
+def save_poi_pool(pool: POIPool):
+    """
+    Saves a POIPool to Firestore
+
+    :param pool: POIPool to save
+    """
+    poi_pool_collection().document(pool.poi_id).set(pool.to_dict())
+
+
+def add_user_to_poi_pool(user: User, poi: POI):
+    """
+    Adds a user to the POIPool correpsonding to the specified POI
+
+    :param user: User to add to pool
+    :param poi: POI corresponding to desired POIPool
+    :raises POIPoolNotFoundError: if there is no POIPool for the specified POI
+    """
+    poi_pool: POIPool = get_pool_for_poi(poi)
+    poi_pool.update_user_in_pool(user.email)
+    save_poi_pool(poi_pool)
+
+
+def remove_user_from_poi_pool(user: User, poi: POI):
+    """
+    Removes a user from the POIPool correpsonding to the specified POI
+
+    :param user: User to remove from pool
+    :param poi: POI corresponding to desired POIPool
+    :raises POIPoolNotFoundError: if there is no POIPool for the specified POI
+    :raises UserNotInPoolError: if specified user is not in the desired pool
+    """
+    poi_pool: POIPool = get_pool_for_poi(poi)
+    poi_pool.remove_user_from_pool(user.email)
+    save_poi_pool(poi_pool)
+
+
+def compute_wait_time_from_poi_pool(poi: POI) -> float:
+    """
+    Computes the wait time estimated from POIPool data
+
+    :param poi: POI to calculate pool wait time for
+    :returns: float corresponding to average wait time in minutes
+    """
+    poi_pool: POIPool = get_pool_for_poi(poi)
+    return poi_pool.current_average_wait_time
+
+
+def get_user_current_poi_pool(user: User) -> Optional[POIPool]:
+    """
+    Gets a POIPool that the specified user is participating in
+
+    :param user: User to search for in pools
+    :returns: POIPool that User is participating in, None if there is none
+    """
+    query = poi_pool_collection().where(f"pool.{user.email}", "!=", "")
+    result = query.get()
+    # Raise an error if the user is in more than one pool at once (we should know about this)
+    assert len(result) < 2
+    if result:
+        return _get_pool_for_poi_id(result[0].id)
+
+    return None
+
+
+def _get_pool_for_poi_id(poi_id: str) -> POIPool:
+    pool_ref = poi_pool_collection().document(poi_id).get()
+    if not pool_ref.exists:
+        raise POIPoolNotFoundError(poi_id)
+    return POIPool.from_dict(poi_id, pool_ref.to_dict())

--- a/app/wait_time/sourcing_data.py
+++ b/app/wait_time/sourcing_data.py
@@ -64,7 +64,7 @@ class POIPool:
                 current_average_wait_time=dict["current_average_wait_time"],
             )
         except KeyError as e:
-            raise BadDataError(f"Missing data from POIPool data: {str(e)}")
+            raise BadDataError(f"Missing data from POIPool data: {str(e)}", 500)
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -88,7 +88,7 @@ class POIPool:
             try:
                 self.pool[user]["last_seen"] = current_timestamp
             except KeyError as e:
-                raise BadDataError(f"Missing data from POI Pool entry: {str(e)}")
+                raise BadDataError(f"Missing data from POI Pool entry: {str(e)}", 500)
         else:
             self.pool[user] = {
                 "start_time": current_timestamp,
@@ -114,7 +114,7 @@ class POIPool:
         try:
             wait_time = (current_timestamp - user_pool_data["start_time"]).seconds / 60
         except KeyError as e:
-            raise BadDataError(f"Missing data from POI Pool entry: {str(e)}")
+            raise BadDataError(f"Missing data from POI Pool entry: {str(e)}", 500)
 
         self.recent_wait_times[current_timestamp.isoformat()] = wait_time
 

--- a/app/wait_time/sourcing_data.py
+++ b/app/wait_time/sourcing_data.py
@@ -2,7 +2,6 @@
 from typing import Dict, Any, Optional
 from datetime import datetime, timezone, timedelta
 from app.common import BadDataError
-from math import ceil
 
 
 class POIPool:

--- a/app/wait_time/sourcing_data.py
+++ b/app/wait_time/sourcing_data.py
@@ -30,7 +30,7 @@ class POIPool:
         self.total_user_count = total_user_count
 
     @classmethod
-    def from_dict(poi_id: str, dict: Dict[str, Any]):
+    def from_dict(poi_id: str, dict: Dict[str, Any]) -> "POIPool":
         """
         Create a new POIPool from a dict in the following format:
         {
@@ -46,8 +46,25 @@ class POIPool:
 
         :param poi_id: ID of the POI
         :param dict: Dict containing pool data in the above format
+        :returns: POIPool initialized with data from the given dictionary
         """
-        pass
+        try:
+            return POIPool(
+                poi_id=poi_id,
+                pool_data=dict["pool"],
+                average_wait_per_user=dict["average_wait_per_user"],
+                total_user_count=dict["total_user_count"],
+            )
+        except KeyError as e:
+            raise BadDataError(f"Missing data from POIPool data: {str(e)}")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary containing all properties from the POIPool
+
+        :returns: dictionary containing key-value pairs with all POIPool data
+        """
+        return self.__dict__
 
     def get_wait_time_estimate(self) -> int:
         return ceil(self.average_wait_per_user * len(self.pool_data))

--- a/app/wait_time/sourcing_data.py
+++ b/app/wait_time/sourcing_data.py
@@ -17,7 +17,7 @@ class POIPool:
         poi_id: str,
         pool: Dict[str, Dict[str, datetime]] = {},
         recent_wait_times: Dict[str, float] = {},
-        current_average_wait_time: Optional[float] = None,
+        current_average_wait_time: float = -1,
     ):
         """
         :param poi_id: ID of the POI as string
@@ -29,7 +29,7 @@ class POIPool:
         self.pool = pool
         self.recent_wait_times = recent_wait_times
         self.current_average_wait_time = current_average_wait_time
-        if self.current_average_wait_time is None:
+        if self.current_average_wait_time < 0:
             self._recompute_average_wait_time()
 
     @staticmethod

--- a/app/wait_time/sourcing_data.py
+++ b/app/wait_time/sourcing_data.py
@@ -1,7 +1,7 @@
 # Data classes used for sourcing will be placed here
 from typing import Dict, Any, Optional
 from datetime import datetime, timezone, timedelta
-from common import BadDataError
+from app.common import BadDataError
 from math import ceil
 
 
@@ -63,7 +63,10 @@ class POIPool:
 
         :returns: dictionary containing key-value pairs with all POIPool data
         """
-        return self.__dict__
+        dict = self.__dict__
+        # Delete primary key before returning dict
+        del dict["poi_id"]
+        return dict
 
     def update_user_in_pool(self, user: str):
         """

--- a/app/wait_time/sourcing_data.py
+++ b/app/wait_time/sourcing_data.py
@@ -1,0 +1,70 @@
+# Data classes used for sourcing will be placed here
+from typing import Dict, Any, Optional
+from datetime import datetime, timezone, timedelta
+
+
+class POIPool:
+    """
+    User pool corresponding to a specific POI. Timestamps for when a user is added to a pool and when they were last
+    seen are recorded for each user in the pool.
+    """
+
+    def __init__(
+        self,
+        poi_id: str,
+        pool_data: Dict[str, Dict[str, datetime]] = {},
+        current_average_waittime: Optional[int] = None,
+    ):
+        """
+        :param poi_id: ID of the POI as string
+        :param pool_data: Pool data dict formatted as {"email": {"start_time": datetime, "last_seen": datetime}, ...}
+        :param current_average_waittime: Current average wait time of users in pool (if available)
+        """
+        self.poi_id = poi_id
+        self.pool_data = pool_data
+        self._current_average_waittime = (
+            self._compute_average_wait_time()
+            if current_average_waittime is None
+            else current_average_waittime
+        )
+
+    def _compute_average_wait_time(self):
+        """Recompute current average wait time"""
+        now = datetime.now(timezone.utc)
+
+        total_seconds = 0
+        for time in self.pool_data.values():
+            time_delta: timedelta = now - time
+            total_seconds += time_delta.seconds
+
+        self._current_average_waittime = total_seconds // len(self.pool_data)
+        return self._current_average_waittime
+
+    def get_average_wait_time(self):
+        """Returns the current average wait time of the pool"""
+        return self._current_average_waittime
+
+    def add_user_to_pool(self, email: str):
+        """
+        Add a new user to the pool
+
+        :param email: Email of the user to add
+        """
+        current_timestamp = datetime.now(timezone.utc)
+        if email in self.pool_data:
+            self.pool_data[email]["last_seen"] = current_timestamp
+        else:
+            self.pool_data[email] = {
+                "start_time": current_timestamp,
+                "last_seen": current_timestamp,
+            }
+            self._compute_average_wait_time()
+
+    def remove_user_from_pool(self, email: str):
+        """
+        Removes a user from the pool
+
+        :param email: Email of the user to remove
+        """
+        del self.pool_data[email]
+        self._compute_average_wait_time()

--- a/app/wait_time/sourcing_data.py
+++ b/app/wait_time/sourcing_data.py
@@ -28,11 +28,9 @@ class POIPool:
         self.poi_id = poi_id
         self.pool = pool
         self.recent_wait_times = recent_wait_times
-        self.current_average_wait_time = (
+        self.current_average_wait_time = current_average_wait_time
+        if self.current_average_wait_time is None:
             self._recompute_average_wait_time()
-            if current_average_wait_time is None
-            else current_average_wait_time
-        )
 
     @staticmethod
     def from_dict(poi_id: str, dict: Dict[str, Any]) -> "POIPool":

--- a/app/wait_time/sourcing_data.py
+++ b/app/wait_time/sourcing_data.py
@@ -34,7 +34,7 @@ class POIPool:
             else current_average_wait_time
         )
 
-    @classmethod
+    @staticmethod
     def from_dict(poi_id: str, dict: Dict[str, Any]) -> "POIPool":
         """
         Create a new POIPool from a dict in the following format:

--- a/test/wait_time/test_poi_pool.py
+++ b/test/wait_time/test_poi_pool.py
@@ -25,7 +25,7 @@ class TestPOIPool(unittest.TestCase):
         }
         self.sample_pool = POIPool(
             "tim_hortons_musc",
-            pool_data=self.sample_pool_dict["pool"],
+            pool=self.sample_pool_dict["pool"],
             recent_wait_times=self.sample_pool_dict["recent_wait_times"],
             current_average_wait_time=self.sample_pool_dict[
                 "current_average_wait_time"
@@ -40,9 +40,9 @@ class TestPOIPool(unittest.TestCase):
 
     def test_update_user_in_pool(self):
         self.sample_pool.update_user_in_pool("test@sample.com")
-        self.assertEqual(len(self.sample_pool.pool_data), 1)
+        self.assertEqual(len(self.sample_pool.pool), 1)
         self.sample_pool.update_user_in_pool("newuser@sample.com")
-        self.assertEqual(len(self.sample_pool.pool_data), 2)
+        self.assertEqual(len(self.sample_pool.pool), 2)
 
     def test_is_user_in_pool(self):
         self.assertTrue(self.sample_pool.is_user_in_pool("test@sample.com"))
@@ -51,7 +51,7 @@ class TestPOIPool(unittest.TestCase):
     def test_remove_user_from_pool(self):
         old_wait_time = self.sample_pool.current_average_wait_time
         self.sample_pool.remove_user_from_pool("test@sample.com")
-        self.assertEqual(len(self.sample_pool.pool_data), 0)
+        self.assertEqual(len(self.sample_pool.pool), 0)
         # This user has a wait time of about 300 seconds, so new average wait time should be less than before
         self.assertLess(self.sample_pool.current_average_wait_time, old_wait_time)
         # Check that outgoing wait time has been added to recent wait times

--- a/test/wait_time/test_poi_pool.py
+++ b/test/wait_time/test_poi_pool.py
@@ -1,0 +1,72 @@
+import unittest
+
+from app.wait_time.sourcing_data import POIPool
+from datetime import datetime, timezone, timedelta
+
+
+class TestPOIPool(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        sample_iso_timestamp1 = (
+            datetime.now(timezone.utc) - timedelta(seconds=400)
+        ).isoformat()
+        sample_iso_timestamp2 = (
+            datetime.now(timezone.utc) - timedelta(seconds=1900)
+        ).isoformat()
+        self.sample_pool_dict = {
+            "current_average_wait_time": 8,
+            "pool": {
+                "test@sample.com": {
+                    "start_time": datetime.now(timezone.utc) - timedelta(seconds=300),
+                    "last_seen": datetime.now(timezone.utc) - timedelta(seconds=100),
+                }
+            },
+            "recent_wait_times": {sample_iso_timestamp1: 6, sample_iso_timestamp2: 9},
+        }
+        self.sample_pool = POIPool(
+            "tim_hortons_musc",
+            pool_data=self.sample_pool_dict["pool"],
+            recent_wait_times=self.sample_pool_dict["recent_wait_times"],
+            current_average_wait_time=self.sample_pool_dict[
+                "current_average_wait_time"
+            ],
+        )
+
+    def test_to_from_dict(self):
+        self.assertEqual(
+            self.sample_pool,
+            POIPool.from_dict("tim_hortons_musc", self.sample_pool_dict),
+        )
+
+    def test_update_user_in_pool(self):
+        self.sample_pool.update_user_in_pool("test@sample.com")
+        self.assertEqual(len(self.sample_pool.pool_data), 1)
+        self.sample_pool.update_user_in_pool("newuser@sample.com")
+        self.assertEqual(len(self.sample_pool.pool_data), 2)
+
+    def test_is_user_in_pool(self):
+        self.assertTrue(self.sample_pool.is_user_in_pool("test@sample.com"))
+        self.assertFalse(self.sample_pool.is_user_in_pool("nonexistent@sample.com"))
+
+    def test_remove_user_from_pool(self):
+        old_wait_time = self.sample_pool.current_average_wait_time
+        self.sample_pool.remove_user_from_pool("test@sample.com")
+        self.assertEqual(len(self.sample_pool.pool_data), 0)
+        # This user has a wait time of about 300 seconds, so new average wait time should be less than before
+        self.assertLess(self.sample_pool.current_average_wait_time, old_wait_time)
+        # Check that outgoing wait time has been added to recent wait times
+        self.assertEqual(len(self.sample_pool.recent_wait_times), 3)
+        # Check that user has been removed from pool
+        self.assertFalse(self.sample_pool.is_user_in_pool("test@sample.com"))
+
+    def test_clear_stale_wait_times(self):
+        self.sample_pool.clear_stale_wait_times()
+        self.assertEqual(len(self.sample_pool.recent_wait_times), 1)
+        self.sample_pool.clear_stale_wait_times(ttl=300)
+        self.assertEqual(len(self.sample_pool.recent_wait_times), 0)
+
+    def test_clear_stale_pool_users(self):
+        self.sample_pool.clear_stale_pool_users()  # should do nothing
+        self.assertTrue(self.sample_pool.is_user_in_pool("test@sample.com"))
+        self.sample_pool.clear_stale_pool_users(ttl=100)
+        self.assertFalse(self.sample_pool.is_user_in_pool("test@sample.com"))

--- a/test/wait_time/test_poi_pool.py
+++ b/test/wait_time/test_poi_pool.py
@@ -39,8 +39,13 @@ class TestPOIPool(unittest.TestCase):
         )
 
     def test_update_user_in_pool(self):
+        previous_last_seen = self.sample_pool.pool["test@sample.com"]["last_seen"]
         self.sample_pool.update_user_in_pool("test@sample.com")
         self.assertEqual(len(self.sample_pool.pool), 1)
+        self.assertGreater(
+            self.sample_pool.pool["test@sample.com"]["last_seen"],
+            previous_last_seen,
+        )
         self.sample_pool.update_user_in_pool("newuser@sample.com")
         self.assertEqual(len(self.sample_pool.pool), 2)
 

--- a/test/wait_time/test_service.py
+++ b/test/wait_time/test_service.py
@@ -1,10 +1,15 @@
 import unittest
 from unittest.mock import patch, Mock
-from app.user.user import User
+from test.mixins.firebase_mixin import FirebaseTestMixin
 
+from datetime import datetime, timezone, timedelta
+from app.firebase import firestore_db, POI_COLLECTION
+from app.user.user import User
 from app.wait_time import service as wait_time_service
 from app.wait_time.location import UserLocation
 from app.locations.poi import POI
+from app.wait_time.sourcing_data import POIPool
+from app.wait_time.errors import UserNotInPoolError, UserAlreadyInPoolError
 
 SAMPLE_UID = "2Nc3UKvI98YvhTlud9ZEomZHr9p2"
 
@@ -58,3 +63,114 @@ class TestWaitTimeService(unittest.TestCase):
             self.test_user, "tim_hortons_musc", 5
         )
         mock_waittime_submit_func.assert_called_once()
+
+
+# Separate class for computation tests to utilize Firebase Emulator instead of mocking
+class TestWaitTimeComputation(unittest.TestCase, FirebaseTestMixin):
+    @classmethod
+    def setUpClass(self):
+        self.with_firebase_emulators(self)
+        sample_iso_timestamp1 = (
+            datetime.now(timezone.utc) - timedelta(seconds=400)
+        ).isoformat()
+        sample_iso_timestamp2 = (
+            datetime.now(timezone.utc) - timedelta(seconds=1900)
+        ).isoformat()
+        self.sample_pool_dict = {
+            "current_average_wait_time": 8,
+            "pool": {
+                "test@sample.com": {
+                    "start_time": datetime.now(timezone.utc) - timedelta(seconds=300),
+                    "last_seen": datetime.now(timezone.utc) - timedelta(seconds=100),
+                }
+            },
+            "recent_wait_times": {sample_iso_timestamp1: 6, sample_iso_timestamp2: 9},
+        }
+
+    def setUp(self):
+        self.test_user = User("test@sample.com")
+        self.with_user_accounts(self.test_user)
+        self.sample_pool = POIPool(
+            "tim_hortons_musc",
+            pool=self.sample_pool_dict["pool"],
+            recent_wait_times=self.sample_pool_dict["recent_wait_times"],
+            current_average_wait_time=self.sample_pool_dict[
+                "current_average_wait_time"
+            ],
+        )
+        # Sample POI
+        self.sample_poi = POI(
+            id="tim_hortons_musc",
+            name="Tim Hortons MUSC",
+            classification="queue",
+            hours_of_operation={
+                "Sunday": "Closed",
+                "Monday": "7:30 AM - 9:00 PM",
+                "Tuesday": "7:30 AM - 9:00 PM",
+                "Wednesday": "7:30AM - 9:00 PM",
+                "Thursday": "7:30 AM - 9:00 PM",
+                "Friday": "7:30 AM - 8:00 PM",
+                "Saturday": "Closed",
+            },
+            address="McMaster University Student Centre",
+            poi_type="EATERY",
+            location={
+                "latitude": 43.263532187492686,
+                "longitude": -79.91758503073444,
+            },
+            image_url="https://discover.mcmaster.ca/app/uploads/2019/06/Booster-Juice.jpg",
+        )
+        firestore_db().collection(POI_COLLECTION).document(self.sample_poi.id).set(
+            self.sample_poi.to_dict()
+        )
+
+        wait_time_service.save_poi_pool(self.sample_pool)
+
+    def tearDown(self):
+        self.delete_user_accounts()
+        self.clear_all_firestore_data()
+
+    def test_get_pool_for_poi(self):
+        self.assertEqual(
+            wait_time_service.get_pool_for_poi(self.sample_poi), self.sample_pool
+        )
+
+    def test_save_poi_pool(self):
+        firestore_db().collection(POI_COLLECTION).document(self.sample_poi.id).delete()
+        wait_time_service.save_poi_pool(self.sample_pool)
+        self.assertEqual(
+            wait_time_service.get_pool_for_poi(self.sample_poi), self.sample_pool
+        )
+
+    def test_add_user_to_pool(self):
+        self.assertRaises(
+            UserAlreadyInPoolError,
+            wait_time_service.add_user_to_poi_pool,
+            self.test_user,
+            self.sample_poi,
+        )
+        wait_time_service.remove_user_from_poi_pool(self.test_user, self.sample_poi)
+        wait_time_service.add_user_to_poi_pool(self.test_user, self.sample_poi)
+        self.assertTrue(wait_time_service.get_user_current_poi_pool(self.test_user))
+
+    def test_remove_user_from_pool(self):
+        wait_time_service.remove_user_from_poi_pool(self.test_user, self.sample_poi)
+        self.assertFalse(wait_time_service.get_user_current_poi_pool(self.test_user))
+        self.assertRaises(
+            UserNotInPoolError,
+            wait_time_service.remove_user_from_poi_pool,
+            self.test_user,
+            self.sample_poi,
+        )
+
+    def test_get_user_current_poi_pool(self):
+        self.assertEqual(
+            wait_time_service.get_user_current_poi_pool(self.test_user),
+            self.sample_pool,
+        )
+
+    def test_get_wait_time_from_poi_pool(self):
+        self.assertEqual(
+            self.sample_pool.current_average_wait_time,
+            wait_time_service.get_wait_time_from_poi_pool(self.sample_poi),
+        )


### PR DESCRIPTION
## Overview

The first of several PRs for computation. This one focuses on wait time calculations from user pools. I've detailed my approach for POI pool calculations below. While the implementation I've done here is pretty much ready to go, I would still like to get as much feedback as possible, this can definitely be reworked if anyone has a better approach.

This change is a

- [x] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change exisiting functionality)
- [ ] Documentation update

## Description

### Calculation Overview

POI Pools will be kept on Firestore in a single document per POI. The format is as follows:
```
"current_average_wait_time": float,
"pool": {
        "email": {
            "start_time": datetime,
            "last_seen": datetime
                 },...
            },
"recent_wait_times": {
          "<ISO-timestamp>": float,
          ...
}
```

The "pool" is a mapping between users and the time they were first added to the pool. There is also a "last_seen" timestamp to keep track of when the user's location was last updated. The plan is to prune any users that have not been seen in a certain period of time (e.g., 5 minutes), in the case that we never get another location update from the user and we need to prune them from the pool (e.g., they closed the app before we could get another update, etc).

When a user is removed from the pool, the delta between the time of removal and the time they were added is the time it took for the user to be served. This time is recorded in "recent_wait_times". The timestamp of the user's removal from the pool will be recorded along with this time in a map. Average wait time will be calculated by taking the average of all times in "recent_wait_times". The plan is to keep the times here to wait times within a certain period of time (e.g., 30 minutes), so older wait times recorded in "recent_wait_times" will be pruned to keep the average current.

### New Classes and Functions

#### POIPool

This data class encapsulates all data from the pool and also handles calculations that occur when a user is added to or removed from the queue.

#### New wait_time service functions

- New functions have been added to handle the logic of adding and removing a user to and from a POI pool: `add_user_to_poi_pool(User, POI)`, `remove_user_from_poi_pool(User, POI)`
- A few other helper functions related to POI Pools (see the wait_time service file)
- A new `compute_wait_time_for_poi(POI)` function that will now be the main method to calculate the overall wait time for a POI'

### Other minor stuff added
- Updated `BadDataError` to allow other status codes other than 400 (to indicate server-sided errors)
- Tests added for new computation functions and data type

## Next Steps

### POI Pool Functionality

This mostly completes wait time calculations on the service side only. Some important additions need to be added to make this functional. Namely:
- The logic needs to be added to handle a user's location and check if they are within range of a POI so that they can be added to the appropriate pool. Likewise, logic should be added to remove a user from the pools they are in if they move away from a POI. 
- A scheduled function needs to run regularly to prune stale users from the pool and update the wait time calculations regularly. Something like [APScheduler](https://pypi.org/project/APScheduler/) can be used for this, and this task should be addressed as part of #37 

### Other sourcing methods

A good chunk of wait time calculation has now been mostly implemented, but Histogram data and manual user submission data are still not a part of the calculation yet. At this time, the `compute_wait_time_for_poi()` function only takes the value from the POI Pools, however this will be expanded to include a weighted average of historical data and manual user submissions. With Histograms being a big chunk of sourcing, I'll leave that part to @dizona , I can add manual user submissions in a future PR.

