### PR TITLE
[LOG] Add logging to waitress in prod

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
         @app.app.after_request
         def after_request_func(response):
             logger.debug(
-                f'[{datetime.now(timezone.utc).strftime("%d/%b/%Y %H:%M:%S")}] "{request.method} {request.path}{"?"+request.query_string.decode("utf-8") if request.query_string else ""} {request.scheme.upper()}" {response.status_code}'
+                f'[{datetime.now(timezone.utc).strftime("%d/%b/%Y %H:%M:%S")}] {request.remote_addr} "{request.method} {request.path}{"?"+request.query_string.decode("utf-8") if request.query_string else ""} {request.scheme.upper()}" {response.status_code}'
                 f'{NEWLINE + str(request.form.to_dict()) if request.form else ""}'
                 f'{NEWLINE + str(request.json) if request.is_json else ""}'
                 f'{NEWLINE + str(response.data.decode("utf-8")).strip() if response.data else ""}'

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 import os
-
+from datetime import datetime, timezone
+from flask import request
 from setup import initialize_firebase, start_server, FIREBASE_CERT_PATH
 
 
@@ -17,6 +18,21 @@ if __name__ == "__main__":
     if env == "prod":
         # Run the app in production mode with waitress.
         from waitress import serve
+        import logging
+
+        logger = logging.getLogger("waitress")
+        logger.setLevel(logging.DEBUG)
+        NEWLINE = "\n"
+
+        @app.app.after_request
+        def after_request_func(response):
+            logger.debug(
+                f'[{datetime.now(timezone.utc).strftime("%d/%b/%Y %H:%M:%S")}] "{request.method} {request.path}{"?"+request.query_string.decode("utf-8") if request.query_string else ""} {request.scheme.upper()}" {response.status_code}'
+                f'{NEWLINE + str(request.form.to_dict()) if request.form else ""}'
+                f'{NEWLINE + str(request.json) if request.is_json else ""}'
+                f'{NEWLINE + str(response.data.decode("utf-8")).strip() if response.data else ""}'
+            )
+            return response
 
         serve(app, host="0.0.0.0", port=5000)
     elif env == "dev":


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Adds a debug log on HTTP request in production to the waitress server, since right now there's nothing in the logs and it's tough to debug in prod.

This change is a

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change exisiting functionality)
- [x] Documentation update

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->

Looks something this 
```
INFO:waitress:Serving on http://0.0.0.0:5000
DEBUG:waitress:[05/Mar/2023 02:00:50] "POST /api/user/referral/CYIRSD?x=20 HTTP"401
{'test': 2}
{
  "detail": "Invalid token. Certificate for key id 15c2b40aa2f322798666a6b332aaa03a6773019b not found.",
  "status": 401,
  "title": "Unauthorized",
  "type": "about:blank"
}
```

## Motivation/Links
More visibility in prod.
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
