### PR TITLE
[FIX] Fix histogram to only make one call

### DIFF
--- a/app/locations/api.py
+++ b/app/locations/api.py
@@ -116,7 +116,7 @@ def get_POI_details(
     poi = get_details_for_POI(poi_id)
     distance = get_distance_to_POI(poi, user_location)
     # TODO: Compute the estimate (time or capacity)
-    SAMPLE_ESTIMATE = fetch_latest_estimated_value(poi_id)
+    SAMPLE_ESTIMATE = fetch_latest_estimated_value(poi_id, poi.classification.value)
     # TODO: Compute the last_updated value
     SAMPLE_LAST_UPDATED = 3
     # TODO: Compute the histogram values that match this format

--- a/test/wait_time/test_histogram_service.py
+++ b/test/wait_time/test_histogram_service.py
@@ -118,24 +118,24 @@ class TestWaitTimeComputation(unittest.TestCase, FirebaseTestMixin):
 
     def test_fetch_latest_estimated_value_queue(self):
         self.assertEqual(
-            fetch_latest_estimated_value(self.poi_id, "Sunday", 1, 10),
+            fetch_latest_estimated_value(self.poi_id, "queue", "Sunday", 1, 10),
             self.sample_wait_time_estimate,
         )
 
     def test_fetch_latest_estimated_value_peak_queur(self):
         self.assertEqual(
-            fetch_latest_estimated_value(self.poi_id, "Sunday", 1, 25),
+            fetch_latest_estimated_value(self.poi_id, "queue", "Sunday", 1, 25),
             self.sample_wait_time_estimate_peak,
         )
 
     def test_fetch_latest_estimated_value_occupancy(self):
         self.assertEqual(
-            fetch_latest_estimated_value(self.poi_id_occ, "Sunday", 1, 10),
+            fetch_latest_estimated_value(self.poi_id_occ, "occupancy", "Sunday", 1, 10),
             self.sample_wait_time_estimate_occ,
         )
 
     def test_fetch_latest_estimated_value_peak_occupancy(self):
         self.assertEqual(
-            fetch_latest_estimated_value(self.poi_id_occ, "Sunday", 1, 25),
+            fetch_latest_estimated_value(self.poi_id_occ, "occupancy", "Sunday", 1, 25),
             self.sample_wait_time_estimate_peak_occ,
         )


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Instead of pulling the data for every day instead just call the day you need. Saves some time and make it manageable.

This change is a

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change exisiting functionality)
- [ ] Documentation update

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->

## Motivation/Links

<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
